### PR TITLE
Weston 11 fix

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -31,7 +31,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include "plugin-registry.h"
 #include "ilm_types.h"
 
 #include "ivi-input-server-protocol.h"

--- a/ivi-layermanagement-api/ilmClient/include/ilm_client_platform.h
+++ b/ivi-layermanagement-api/ilmClient/include/ilm_client_platform.h
@@ -35,7 +35,7 @@ typedef struct _ILM_CLIENT_PLATFORM_FUNC
     ilmErrorTypes (*destroy)();
 } ILM_CLIENT_PLATFORM_FUNC;
 
-ILM_CLIENT_PLATFORM_FUNC gIlmClientPlatformFunc;
+extern ILM_CLIENT_PLATFORM_FUNC gIlmClientPlatformFunc;
 
 void init_ilmClientPlatformTable();
 

--- a/ivi-layermanagement-api/ilmClient/src/ilm_client_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmClient/src/ilm_client_wayland_platform.c
@@ -35,6 +35,8 @@ static ilmErrorTypes wayland_surfaceRemove(const t_ilm_surface surfaceId);
 static ilmErrorTypes wayland_init(t_ilm_nativedisplay nativedisplay);
 static ilmErrorTypes wayland_destroy(void);
 
+ILM_CLIENT_PLATFORM_FUNC gIlmClientPlatformFunc;
+
 void init_ilmClientPlatformTable(void)
 {
     gIlmClientPlatformFunc.surfaceCreate =

--- a/ivi-layermanagement-api/ilmCommon/include/ilm_common_platform.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_common_platform.h
@@ -32,7 +32,7 @@ typedef struct _ILM_COMMON_PLATFORM_FUNC
     ilmErrorTypes (*destroy)();
 } ILM_COMMON_PLATFORM_FUNC;
 
-ILM_COMMON_PLATFORM_FUNC gIlmCommonPlatformFunc;
+extern ILM_COMMON_PLATFORM_FUNC gIlmCommonPlatformFunc;
 
 void init_ilmCommonPlatformTable();
 

--- a/ivi-layermanagement-api/ilmCommon/src/ilm_common_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmCommon/src/ilm_common_wayland_platform.c
@@ -32,6 +32,8 @@ static t_ilm_nativedisplay wayland_getNativedisplay(void);
 static t_ilm_bool wayland_isInitialized(void);
 static ilmErrorTypes wayland_destroy(void);
 
+ILM_COMMON_PLATFORM_FUNC gIlmCommonPlatformFunc;
+
 void init_ilmCommonPlatformTable(void)
 {
     gIlmCommonPlatformFunc.init = wayland_init;

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -84,6 +84,7 @@ struct ivicontroller {
 
 struct ivi_screenshooter {
     struct wl_resource *screenshot;
+    struct weston_output *output;
 };
 
 struct screen_id_info {


### PR DESCRIPTION
Was unable to build without these changes: clearly unintentional mistakes. After changes I was able to build and everything runs fine. Tested on Archlinux with Weston 11.0.0.